### PR TITLE
fix building/linking on rpi1

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -9,7 +9,7 @@ LD=g++
 LDFLAGS=
 LIBS=
 
-ifeq ($(shell uname -m),armv7l)
+ifneq (,$(findstring armv,$(shell uname -m)))
     LDLIBS += -ldl
     LDLIBS += -L/opt/vc/lib -lGLESv2 -lEGL
     CFLAGS += -DHAVE_OPENGLES2 -DVC -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/vmcs_host/linux


### PR DESCRIPTION
the Makefile checks for armv7l - but of course rpi1 is armv6, so it doesn't build/link.
